### PR TITLE
Fix typo in setup.py to make tarsnapper installable again.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,6 @@ setup(name='tarsnapper',
       license='BSD',
       packages=['tarsnapper'],
       package_dir = {'tarsnapper': 'src/tarsnapper'},
-      install_requires = ['argpars>==1.1', 'pyyaml>=3.09'],
+      install_requires = ['argparse>=1.1', 'pyyaml>=3.09'],
       **kw
 )


### PR DESCRIPTION
Thanks for writing tarsnapper. I have been using the http://community.opscode.com/cookbooks/tarsnap cookbook to set up tarsnap on new machines, and the installation recipe for tarsnapper fails with:

"error in tarsnapper setup command: 'install_requires' must be a string or list of strings containing valid project/version requirement specifiers"

I've tested this change and it fixes the problem.
