### PR TITLE
filter tarsnap verbose output in list-archives

### DIFF
--- a/src/tarsnapper/script.py
+++ b/src/tarsnapper/script.py
@@ -89,9 +89,15 @@ class TarsnapBackend(object):
         """A list of archives as returned by --list-archives. Queried
         the first time it is accessed, and then subsequently cached.
         """
+        verbose_flag = ['v'] in self.options
         if self._queried_archives is None:
             response = StringIO(self.call('--list-archives'))
             self._queried_archives = [l.rstrip() for l in response.readlines()]
+            if verbose_flag:
+                # Filter out extraneous info if tarsnap was run with
+                # verbose flag
+                self._queried_archives = [
+                    l.rsplit('\t', 1)[0] for l in self._queried_archives]
         return self._queried_archives + self._known_archives
     archives = property(get_archives)
 

--- a/src/tarsnapper/script.py
+++ b/src/tarsnapper/script.py
@@ -89,11 +89,10 @@ class TarsnapBackend(object):
         """A list of archives as returned by --list-archives. Queried
         the first time it is accessed, and then subsequently cached.
         """
-        verbose_flag = ['v'] in self.options
         if self._queried_archives is None:
             response = StringIO(self.call('--list-archives'))
             self._queried_archives = [l.rstrip() for l in response.readlines()]
-            if verbose_flag:
+            if ['v'] in self.options:
                 # Filter out extraneous info if tarsnap was run with
                 # verbose flag
                 self._queried_archives = [


### PR DESCRIPTION
Thanks a lot for writing tarsnapper!

If tarsnapper is run passing ```-v``` to tarsnap, ```get_archives``` will improperly ignore matching archives due to the extra unexpected tarsnap output.

This pull request detects when tarsnap is running verbosely, and filters ```--list-archives``` output so that it works as-expected.

A couple caveats:

1. Passing ```-v``` to tarsnap doesn't actually do anything user-visible in most cases, as tarsnap output isn't normally displayed.  In my personal fork I log tarsnap stderr and stdout at the debug logging level, but that's a pretty disruptive change.

2. This filter does not tolerate running tarsnap with ```-vv``` or higher, but it looks like tarsnapper's ```-o``` argument doesn't tolerate passing multiple "v"s either.  Again, since running verbosely doesn't really affect user-visible behavior, it's probably not a high priority.  I only make this pull request since README.rst specifically provides an example of passing ```-o v``` to tarsnapper, so this prevents a user walking through README.rst from seeing error messages.