### PR TITLE
Run any exec_before command prior to checking sources

### DIFF
--- a/src/tarsnapper/script.py
+++ b/src/tarsnapper/script.py
@@ -382,7 +382,11 @@ class MakeCommand(ExpireCommand):
                               "sources exist")
             skipped = True
         else:
-            self.backend.make(job)
+            try:
+                self.backend.make(job)
+            except Exception:
+                self.log.error(("Something went wrong with backup job: '%s'")
+                               % job.name)
 
         if job.exec_after:
             self.backend._exec_util(job.exec_after)


### PR DESCRIPTION
As if we check that the backup sources are present first we may fail if
the exec_before is populating one or more of the sources. For example,
we might be dumping a database to what would otherwise be an empty dir.
