### PR TITLE
Add cdbs to build dependencies for Debian package

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: tarsnapper
 Section: net
 Priority: extra
 Maintainer: Joenio Costa <joenio@perl.org.br>
-Build-Depends: debhelper (>= 5), python-support, python-all-dev, python-docutils
+Build-Depends: debhelper (>= 5), python-support, python-all-dev, python-docutils, cdbs
 Standards-Version: 3.9.3.1
 
 Package: tarsnapper


### PR DESCRIPTION
Building a tarsnapper package on Debian requires the "cdbs" package.
