### PR TITLE
Remove Xpect.io support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -161,26 +161,3 @@ off for weeks at a time, using the deltas ``1d 7d 30d 360d 18000d``:
       dropbox-20130312-064042
       dropbox-20120325-054505
       dropbox-20110331-121745
-
-
-Bonus: Support for xpect.io
-===========================
-
-`xpect.io`_ is a neat monitoring system that will trigger an exception if a
-system does not check in regularly. tarsnapper has support for the service
-builtin.
-
-Two values are needed: The **expectation url** and the access key. Both
-can be provided either on the command line, or at the global level in
-the YAML file::
-
-    xpect: https://xpect.io/v1/accounts/42/expectations/99
-    xpect-key: 6173642377656633343b4b617364237
-
-    jobs:
-       ....
-
-
-Additionally, the environment variable ``XPECTIO_ACCESS_KEY`` is supported.
-
-.. _xpect.io: https://xpect.io/

--- a/src/tarsnapper/script.py
+++ b/src/tarsnapper/script.py
@@ -212,43 +212,6 @@ def timedelta_string(value):
         raise argparse.ArgumentTypeError('invalid delta value: %r (suffix d, s allowed)' % e)
 
 
-class XpectIOPlugin(object):
-    """Integrates with xpect.io.
-    """
-
-    def __init__(self):
-        # get access key from ENV
-        self.env_key = os.environ.get('XPECTIO_ACCESS_KEY', None)
-
-    def setup_arg_parser(self, parser):
-        parser.add_argument('--xpect', help='xpect.io url')
-        parser.add_argument('--xpect-key', help='xpect.io access key')
-
-    def all_jobs_done(self, args, config, cmd):
-        if not cmd in (MakeCommand, ExpireCommand):
-            return
-
-        access_key = config.get('xpect-key', args.xpect_key or self.env_key)
-        url = config.get('xpect', args.xpect)
-
-        if url:
-            if not access_key:
-                raise RuntimeError('Cannot notify xpect.io, no access key set')
-
-            urllib2.urlopen(
-                urllib2.Request(
-                    url=url,
-                    headers={
-                        'Content-Type': 'application/json',
-                        'X-Access-Key': access_key,
-                    },
-                    data=json.dumps({
-                        'action': 'eventSuccess'
-                    })
-                )
-            )
-
-
 class Command(object):
 
     BackendClass = TarsnapBackend
@@ -399,7 +362,6 @@ COMMANDS = {
 
 
 PLUGINS = [
-    XpectIOPlugin()
 ]
 
 


### PR DESCRIPTION
Here's a simple patch for #22.

I did not remove the plugin support, even though this was the only (last?) thing using it.