### PR TITLE
Fixed typographical error, changed accomodate to accommodate in README.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -88,7 +88,7 @@ to be part of the same backup set that you want to operate on.
 
 tarsnapper will then look at the date of each archive (this is why
 you need the ``$date`` placeholder) and determine those which are not
-needed to accomodate the given given delta range. It will parse the date
+needed to accommodate the given given delta range. It will parse the date
 using the ``python-dateutil`` library, which supports a vast array of
 different formats, though some restrictions apply: If you are using
 ``yyyy-dd-mm``, it cannot generally differentiate that from ``yyyy-mm-dd``.


### PR DESCRIPTION
miracle2k, I've corrected a typographical error in the documentation of the [tarsnapper](https://github.com/miracle2k/tarsnapper) project. You should be able to merge this pull request automatically. However, if this was intentional or you enjoy living in linguistic squalor please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.