### PR TITLE
Support for passphrase protected keys

### DIFF
--- a/requirements.pip
+++ b/requirements.pip
@@ -1,2 +1,3 @@
 argparse==1.1
 PyYAML==3.09
+pexpect>=3.1

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,6 @@ setup(name='tarsnapper',
       license='BSD',
       packages=['tarsnapper'],
       package_dir = {'tarsnapper': 'src/tarsnapper'},
-      install_requires = ['argparse>=1.1', 'pyyaml>=3.09', 'python-dateutil>=2.4.0'],
+      install_requires = ['argparse>=1.1', 'pyyaml>=3.09', 'python-dateutil>=2.4.0', 'pexpect>=3.1'],
       **kw
 )


### PR DESCRIPTION
The tarsnap client has the ability to use keys protected with a passphrase. When opening such keys it will prompt the user to enter the required credential and proceed afterwards.

This feature is currently not supported in tarsnapper. Instead tarsnapper attempts to read the complete output of the tarsnap client program, which will wait for user input. This means tarsnapper gets essentially stuck when using such keys.

This pull request contains a patch to make tarsnapper search the output of the tarsnap client and prompt the user for a password when tarnsnap requests one. The password gets then forwarded to the tarsnap binary.  Though this also an additional dependency in the form of the pexpect library.