### PR TITLE
Allows definition and usage of named global deltas

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -217,7 +217,7 @@ def test_exclude_and_excludes():
     """)
 
 def test_named_delta():
-    assert len(load_config("""
+    c = load_config("""
     target: $name-$date
     deltas: 1d 10d
     delta-names:
@@ -227,7 +227,15 @@ def test_named_delta():
       foo:
         source: /foo/
         delta: myDelta
-    """)[0]['foo'].deltas) == 3
+      bar:
+        source: /foo/
+        delta: otherDelta
+      baz:
+        source: /foo/
+    """)
+    assert len(c[0]['baz'].deltas) == 2
+    assert len(c[0]['foo'].deltas) == 3
+    assert len(c[0]['bar'].deltas) == 4
 
 def test_unspecified_named_delta():
     assert_raises(ConfigError, load_config, """

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -215,3 +215,51 @@ def test_exclude_and_excludes():
           loo
           moo
     """)
+
+def test_named_delta():
+    assert len(load_config("""
+    target: $name-$date
+    deltas: 1d 10d
+    delta-names:
+      myDelta: 1d 7d 30d
+      otherDelta: 1d 7d 30d 90d
+    jobs:
+      foo:
+        source: /foo/
+        delta: myDelta
+    """)[0]['foo'].deltas) == 3
+
+def test_unspecified_named_delta():
+    assert_raises(ConfigError, load_config, """
+    target: $name-$date
+    delta-names:
+      myDelta:
+    jobs:
+      foo:
+        source: /foo/
+        delta: myDelta
+    """)
+
+def test_undefined_named_delta():
+    assert_raises(ConfigError, load_config, """
+    target: $name-$date
+    delta-names:
+      myDelta: 1d 7d 30d
+    jobs:
+      foo:
+        source: /foo/
+        delta: importantDelta
+    """)
+
+def test_named_delta_and_deltas():
+    """You can't use both named delta and deltas at the same time."""
+    assert_raises(ConfigError, load_config, """
+    target: $name-$date
+    delta-names:
+      myDelta: 1d 7d 30d
+    jobs:
+      foo:
+        source: /foo/
+        delta: myDelta
+        deltas: 5d 10d
+    """)


### PR DESCRIPTION
This will allow named global deltas to be defined and used in jobs like this:
 ```
target: $name-$date
delta-names:
  important: 1h 1d 30d 90d 360d
  standard: 1d 7d 14d 30d 90d
jobs:
  homes:
    source: /home/
    delta: important

  foo:
    source: /etc/foo
    delta: standard
```

I am open for suggestions on how to properly name the `delta-names` config key.