### PR TITLE
Allow jobs to specify their own keyfile, cachedir and a command executed on success

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,8 +47,14 @@ A configuration file looks like this::
         exclude: /var/lib/mysql/temp
         exec_before: service mysql stop
         exec_after: service mysql start
+        # Called only if backup is successful
+        on_success: curl http://example.com/heartbeat
         # Aliases can be used when renaming a job to match old archives.
         alias: img
+        # If present and not empty will set tarsnapper key for this job
+        keyfile:
+        # If present and not empty will override tarsnapper cache dir for this job
+        cachedir:
 
       some-other-job:
         sources:

--- a/requirements.test.pip
+++ b/requirements.test.pip
@@ -1,0 +1,3 @@
+-r requirements.pip
+nose==1.3.7
+mock==2.0.0

--- a/src/tarsnapper/config.py
+++ b/src/tarsnapper/config.py
@@ -66,7 +66,9 @@ class Job(object):
         self.force = initial.get('force')
         self.exec_before = initial.get('exec_before')
         self.exec_after = initial.get('exec_after')
-
+        self.keyfile = initial.get('keyfile')
+        self.cachedir = initial.get('cachedir')
+        self.on_success = initial.get('on_success')
 
 def require_placeholders(text, placeholders, what):
     """Ensure that ``text`` contains the given placeholders.
@@ -192,6 +194,9 @@ def load_config(text):
             'dateformat': job_dict.pop('dateformat', default_dateformat),
             'exec_before': job_dict.pop('exec_before', None),
             'exec_after': job_dict.pop('exec_after', None),
+            'keyfile': job_dict.pop('keyfile', None),
+            'cachedir': job_dict.pop('cachedir', None),
+            'on_success': job_dict.pop('on_success', None)
         })
         if not new_job.target:
             raise ConfigError('%s does not have a target name' % job_name)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -271,3 +271,39 @@ def test_named_delta_and_deltas():
         delta: myDelta
         deltas: 5d 10d
     """)
+
+
+def test_keyfile():
+    """Loading of the "keyfile" option."""
+    c = load_config("""
+     target: $name-$date
+     jobs:
+       foo:
+         source: /foo/
+         keyfile: /etc/tarsnapper/foo.key
+     """)
+    assert c[0]['foo'].keyfile == "/etc/tarsnapper/foo.key"
+
+
+def test_cachedir():
+    """Loading of the "cachedir" option."""
+    c = load_config("""
+     target: $name-$date
+     jobs:
+       foo:
+         source: /foo/
+         cachedir: /var/cache/tarsnap/foo
+     """)
+    assert c[0]['foo'].cachedir == "/var/cache/tarsnap/foo"
+
+
+def test_on_success():
+    """Loading of the "on_success" option."""
+    c = load_config("""
+     target: $name-$date
+     jobs:
+       foo:
+         source: /foo/
+         on_success: curl http://example.com/heartbeat
+     """)
+    assert c[0]['foo'].on_success == "curl http://example.com/heartbeat"


### PR DESCRIPTION
This PR allows jobs to specify their own keyfile, cachedir and command executed on success. 

I have added tests for new functionalities. 