### PR TITLE
Use `pip` rather than `easy_install`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,10 +17,9 @@ A wrapper around tarsnap which does two things:
 Installation
 ============
 
-Using ``easy_install``::
+Using ``pip``::
 
-    $ apt-get install python-setuptools
-    $ easy_install tarsnapper
+    $ pip install tarsnapper
 
 
 Making a single backup without a configuration file


### PR DESCRIPTION
`easy_install` is deprecated in favor of `pip`. 

Including this in the readme just confuses n00bs. Those who genuinely need `easy_install` for legacy reasons will know why/how to use it.