### PR TITLE
Remove superfluous list-casting

### DIFF
--- a/tarsnapper/config.py
+++ b/tarsnapper/config.py
@@ -200,7 +200,7 @@ def load_config(text):
         require_placeholders(new_job.target, ['date'], '%s: target')
         if job_dict:
             raise ConfigError('%s has unsupported configuration values: %s' % (
-                job_name, ", ".join(list(job_dict.keys()))))
+                job_name, ", ".join(job_dict.keys())))
         return new_job
 
     if jobs_section:

--- a/tarsnapper/expire.py
+++ b/tarsnapper/expire.py
@@ -48,12 +48,10 @@ def expire(backups, deltas):
         return []
 
     # First, sort the backups with most recent one first
-    backups = [(name, time) for name, time in list(backups.items())]
-    backups.sort(key=lambda x: x[1], reverse=True)
+    backups = sorted(backups.items(), key=lambda x: x[1], reverse=True)
     old_backups = backups[:]
 
     # Also make sure that we have the deltas in ascending order
-    deltas = list(deltas[:])
     deltas.sort()
 
     # Always keep the most recent backup

--- a/tarsnapper/script.py
+++ b/tarsnapper/script.py
@@ -184,7 +184,7 @@ class TarsnapBackend(object):
 
         # Delete all others
         to_delete = []
-        for name, _ in list(backups.items()):
+        for name in backups.keys():
             if name not in to_keep:
                 to_delete.append(name)
 
@@ -278,15 +278,12 @@ class ListCommand(Command):
     description = 'For each job, output a sorted list of existing backups.'
 
     def run(self, job):
-        backups = self.backend.get_backups(job)
-
         self.log.info('%s', (job.name or "Unnamed job"))
-
+        unsorted_backups = self.backend.get_backups(job).items()
         # Sort backups by time
         # TODO: This duplicates code from the expire module. Should
         # the list of backups always be returned sorted instead?
-        backups = [(name, time) for name, time in list(backups.items())]
-        backups.sort(key=lambda x: x[1], reverse=True)
+        backups = sorted(unsorted_backups, key=lambda x: x[1], reverse=True)
         for backup, _ in backups:
             print("  %s" % backup)
 
@@ -531,7 +528,7 @@ def main(argv):
 
     command = args.command(args, log)
     try:
-        for job in list(jobs_to_run.values()):
+        for job in jobs_to_run.values():
             command.run(job)
 
         for plugin in PLUGINS:

--- a/tarsnapper/test.py
+++ b/tarsnapper/test.py
@@ -47,7 +47,7 @@ class BackupSimulator(object):
     def expire(self):
         keep = self.expire_func(self.backups, self.deltas)
         deleted = []
-        for key in list(self.backups.keys()):
+        for key in self.backups.keys():
             if not key in keep:
                 deleted.append(key)
                 del self.backups[key]


### PR DESCRIPTION
Most of these were pointless because a list is already guaranteed to be
returned by `dict.items()`/`dict.keys()`/`dict.values()`.