### PR TITLE
Fix reuse of deltas, which caused "Skipping 'target', does not define deltas"

### DIFF
--- a/tarsnapper/config.py
+++ b/tarsnapper/config.py
@@ -182,9 +182,9 @@ def load_config(text):
             if delta_name not in named_deltas:
                 raise ConfigError(('%s: Named delta "%s" not defined')
                                   % (job_name, delta_name))
-            deltas = named_deltas[delta_name]
+            deltas = list(named_deltas[delta_name])
         else:
-            deltas = parse_deltas(job_dict.pop('deltas', None)) or default_deltas
+            deltas = parse_deltas(job_dict.pop('deltas', None)) or list(default_deltas)
         new_job = Job(**{
             'name': job_name,
             'sources': sources,


### PR DESCRIPTION
Multiple jobs using the same deltas would reference the same list instance. `expire.py` mutates this list, causing any following jobs using the same deltas to see an empty list and not expire any backups.

Fix by cloning the default and named deltas whenever they are used in a job.

Fixes #61 