### PR TITLE
Ignore codec errors from tarsnap output (#50)

### DIFF
--- a/tarsnapper/config.py
+++ b/tarsnapper/config.py
@@ -184,7 +184,9 @@ def load_config(text):
                                   % (job_name, delta_name))
             deltas = list(named_deltas[delta_name])
         else:
-            deltas = parse_deltas(job_dict.pop('deltas', None)) or list(default_deltas)
+            deltas = parse_deltas(job_dict.pop('deltas', None))
+            if deltas is None and default_deltas is not None:
+                deltas = list(default_deltas)
         new_job = Job(**{
             'name': job_name,
             'sources': sources,

--- a/tarsnapper/script.py
+++ b/tarsnapper/script.py
@@ -71,7 +71,7 @@ class TarsnapBackend(object):
         self.log.debug("Executing: %s", " ".join(args))
         env = os.environ
         child = pexpect.spawn(args[0], args[1:], env=env, timeout=None,
-                              encoding='utf-8')
+                              encoding='utf-8', codec_errors='ignore')
 
         if self.log.isEnabledFor(logging.DEBUG):
             child.logfile = sys.stdout


### PR DESCRIPTION
When archiving file names that does not conform to UTF-8, Python would
throw a UnicodeDecodeError, aborting the backup.

Since we are only interested in matching either a text appearing before
tarsnap starting to list files (key file password prompt) or the
finalization of the archival process (EOF), just ignore all conversion
errors to ensure that the archive is properly created.

This fixes #50 for me.